### PR TITLE
[wip] expose virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .mypy_cache/
 .pytest_cache/
+/.venv

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ shell:
 
 build:
 	$(DOCKER_COMPOSE) build web
+	$(DOCKER_COMPOSE) run --rm web poetry install
 
 dependency-tree:
 	$(DOCKER_COMPOSE) run --rm web /bin/bash -c "poetry show --tree"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -10,5 +10,4 @@ WORKDIR /srv/test-proj
 COPY ./pyproject.toml ./
 COPY ./poetry.lock ./
 
-RUN poetry config settings.virtualenvs.create false
-RUN poetry install
+RUN poetry config settings.virtualenvs.in-project true

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,11 +1,12 @@
 FROM python:3.6
 
+ARG PROJECT_DIR=/srv/test-proj
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PATH "/root/.poetry/bin:$PATH"
 RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 
-WORKDIR /srv/test-proj
+WORKDIR ${PROJECT_DIR}
 
 COPY ./pyproject.toml ./
 COPY ./poetry.lock ./

--- a/docker/dev.env
+++ b/docker/dev.env
@@ -1,2 +1,4 @@
+PROJECT_DIR=/srv/test-proj
+
 FLASK_APP=test_proj
 FLASK_ENV=development

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,9 +5,10 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.dev
-    working_dir: /srv/test-proj
+      args:
+        - PROJECT_DIR=${PROJECT_DIR}
     volumes:
-      - ..:/srv/test-proj
+      - ..:${PROJECT_DIR}
     command: "flask run --host=0.0.0.0"
     ports:
       - "5000:5000"


### PR DESCRIPTION
With this change it would expose the virtualenv as `.venv`.
Additionally it allows to change the project dir, that is because unfortunately files within the venv have the path hard-coded.

Now I can run:
```bash
export PROJECT_DIR=$PWD
make build
```

As the directory is not mounted during docker build, I moved the `poetry install` to `make build`. The consequence is that `make start` without having run `make build` won't work (but we could make that work if necessary).